### PR TITLE
Add auto trait and bump to v0.1.1

### DIFF
--- a/derive-hex/Cargo.toml
+++ b/derive-hex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "derive-hex"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["zer0 <matteo@dusk.network>"]
 edition = "2018"
 

--- a/dusk-bytes/Cargo.toml
+++ b/dusk-bytes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-bytes"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["zer0 <matteo@dusk.network>"]
 edition = "2018"
 

--- a/dusk-bytes/src/parse.rs
+++ b/dusk-bytes/src/parse.rs
@@ -48,3 +48,6 @@ fn val(c: u8) -> Option<u8> {
         _ => None,
     }
 }
+
+// Auto trait [`ParseHexStr`] for any type that implements [`Serializable`]
+impl<T, const N: usize> ParseHexStr<N> for T where T: Serializable<N> {}

--- a/dusk-bytes/src/serialize.rs
+++ b/dusk-bytes/src/serialize.rs
@@ -43,3 +43,7 @@ pub trait DeserializableSlice<const N: usize>: Serializable<N> {
         }
     }
 }
+
+// Implements automatically [`DeserializableSlice`] for any type that implements
+// [`Serializable`]
+impl<T, const N: usize> DeserializableSlice<N> for T where T: Serializable<N> {}

--- a/dusk-bytes/src/serialize.rs
+++ b/dusk-bytes/src/serialize.rs
@@ -44,6 +44,6 @@ pub trait DeserializableSlice<const N: usize>: Serializable<N> {
     }
 }
 
-// Implements automatically [`DeserializableSlice`] for any type that implements
+// Auto trait [`DeserializableSlice`] for any type that implements
 // [`Serializable`]
 impl<T, const N: usize> DeserializableSlice<N> for T where T: Serializable<N> {}

--- a/dusk-bytes/tests/common/mod.rs
+++ b/dusk-bytes/tests/common/mod.rs
@@ -1,0 +1,48 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use dusk_bytes::{BadLength, InvalidChar, Serializable};
+
+use dusk_bytes::HexDebug;
+#[derive(HexDebug)]
+pub struct Beef {}
+
+#[derive(Debug)]
+pub enum BeefError {
+    InvalidBytes,
+    UnexpectedEof,
+    CharNotValid(char, usize),
+}
+
+impl Serializable<2> for Beef {
+    type Error = BeefError;
+    fn from_bytes(buf: &[u8; Self::SIZE]) -> Result<Self, Self::Error> {
+        if buf[0] == 0xbe && buf[1] == 0xef {
+            Ok(Self {})
+        } else {
+            Err(BeefError::InvalidBytes)
+        }
+    }
+
+    fn to_bytes(&self) -> [u8; Self::SIZE] {
+        [0xbe, 0xef]
+    }
+}
+
+// Implementing DeserializableSlice requires `Error` to implements `BadLength`
+// too
+impl BadLength for BeefError {
+    fn bad_length(_found: usize, _expected: usize) -> Self {
+        Self::UnexpectedEof
+    }
+}
+
+// Implementing ParseHexStr requires `Error` to implements `InvalidChar` too
+impl InvalidChar for BeefError {
+    fn invalid_char(ch: char, index: usize) -> Self {
+        Self::CharNotValid(ch, index)
+    }
+}

--- a/dusk-bytes/tests/parse_test.rs
+++ b/dusk-bytes/tests/parse_test.rs
@@ -1,0 +1,40 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+
+mod common;
+use common::{Beef, BeefError};
+
+use dusk_bytes::ParseHexStr;
+
+#[test]
+fn parse_correct_chars() -> Result<(), BeefError> {
+    let beef = Beef::from_hex_str("beef")?;
+
+    assert_eq!(format!("{:x}", beef), "beef");
+
+    Ok(())
+}
+
+#[test]
+fn parse_invalid_chars() {
+    let beef = Beef::from_hex_str("beqf");
+
+    let result = matches!(beef, Err(BeefError::CharNotValid('q', 2)));
+    assert!(
+        result,
+        "Expected parse failing at index 2 for character 'q'"
+    )
+}
+
+#[test]
+fn parse_wrong_chars() {
+    let beef = Beef::from_hex_str("abcd");
+
+    let result = matches!(beef, Err(BeefError::InvalidBytes));
+    assert!(
+        result,
+        "Expected parse failing because invalid bytes for Beef"
+    )
+}

--- a/dusk-bytes/tests/parse_test.rs
+++ b/dusk-bytes/tests/parse_test.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
+// Copyright (c) DUSK NETWORK. All rights reserved.
 
 mod common;
 use common::{Beef, BeefError};

--- a/dusk-bytes/tests/serialize_test.rs
+++ b/dusk-bytes/tests/serialize_test.rs
@@ -4,43 +4,10 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use dusk_bytes::{BadLength, DeserializableSlice, Serializable};
+mod common;
+use common::{Beef, BeefError};
 
-use dusk_bytes::HexDebug;
-#[derive(HexDebug)]
-struct Beef {}
-
-#[derive(Debug)]
-enum BeefError {
-    InvalidBytes,
-    UnexpectedEof,
-}
-
-impl Serializable<2> for Beef {
-    type Error = BeefError;
-    fn from_bytes(buf: &[u8; Self::SIZE]) -> Result<Self, Self::Error> {
-        if buf[0] == 0xbe && buf[1] == 0xef {
-            Ok(Self {})
-        } else {
-            Err(BeefError::InvalidBytes)
-        }
-    }
-
-    fn to_bytes(&self) -> [u8; Self::SIZE] {
-        [0xbe, 0xef]
-    }
-}
-
-// This implements automatically `from_bytes_slice` and length checks
-impl DeserializableSlice<2> for Beef {}
-
-// Implementing DeserializableSlice requires `Error` to implements `BadLength`
-// too
-impl BadLength for BeefError {
-    fn bad_length(_found: usize, _expected: usize) -> Self {
-        Self::UnexpectedEof
-    }
-}
+use dusk_bytes::{DeserializableSlice, Serializable};
 
 #[test]
 fn expected_size() {


### PR DESCRIPTION
- Add auto trait for `DeserializeSlice` and `ParseHexStr`
- Modify tests accordingly
- Rearrange tests structure
- Bump to v0.1.1

Solves: #8 