### PR TITLE
derive-hex: Fix incorrect alternate hex display for debug mode

### DIFF
--- a/derive-hex/CHANGELOG.md
+++ b/derive-hex/CHANGELOG.md
@@ -1,0 +1,38 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.2] - 2021-07-15
+
+### Fixed
+
+- Fix incorrect alternate hex display for debug mode [#10]
+
+## [0.1.1] - 2021-01-22
+
+### Added
+
+- Add LICENSE
+- Add tests
+
+### Changed
+
+- Change to workspace
+
+## [0.1.0] - 2021-01-13
+
+### Added
+
+- Add `Hex` proc macro
+- Add `HexDebug` proc macro
+
+[#10]: https://github.com/dusk-network/dusk-bytes/issues/10
+[unreleased]: https://github.com/dusk-network/dusk-bytes/compare/derive-hex-0.1.2...HEAD
+[0.1.2]: https://github.com/dusk-network/dusk-bytes/releases/tag/derive-hex-0.1.2
+[0.1.1]: https://github.com/dusk-network/dusk-bytes/releases/tag/derive-hex-0.1.1
+[0.1.0]: https://github.com/dusk-network/dusk-bytes/releases/tag/derive-hex-0.1.0

--- a/derive-hex/Cargo.toml
+++ b/derive-hex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "derive-hex"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["zer0 <matteo@dusk.network>"]
 edition = "2018"
 

--- a/derive-hex/src/lib.rs
+++ b/derive-hex/src/lib.rs
@@ -57,10 +57,28 @@ pub fn derive_hex_debug(item: TokenStream) -> TokenStream {
     let dbg: TokenStream = (quote! {
     impl core::fmt::Debug for #ident {
         fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                write!(f, "{:x}", &self)
+            // Once we format an object using the debug notation (e.g. `{:x?}`)
+            // there is absolutely NO WAY to detect the flag for the lowerhex
+            // or upperhex, and therefore forwarding to the relevant formatter.
+            // Two methods for this purpose exists, but they're not exposed
+            // because they didn't agree on a name yet, see:
+            // <https://github.com/rust-lang/rust/blob/90442458ac46b1d5eed752c316da25450f67285b/library/core/src/fmt/mod.rs#L1817-L1825>
+            //
+            // Therefore the only way is using the deprecated method `flags`,
+            // implementing the same logic of the forementioned methods.
+
+            // We also do not have access to the `FlagV1` enum since it's
+            // private.
+            let FlagV1_DebugUpperHex = 5_u32;
+
+            #[allow(deprecated)]
+            if f.flags() & (1 << FlagV1_DebugUpperHex) !=0 {
+                core::fmt::UpperHex::fmt(self, f)
+            } else { // LowerHex is always the default for debug
+                core::fmt::LowerHex::fmt(self, f)
             }
         }
-    })
+    }})
     .into();
 
     hex.extend(dbg);

--- a/derive-hex/tests/hex_test.rs
+++ b/derive-hex/tests/hex_test.rs
@@ -20,30 +20,66 @@ impl Beef {
     }
 }
 
-#[test]
-fn lower_hex() {
-    let beef = Beef {};
+mod display {
+    use super::*;
 
-    assert_eq!(format!("{:x}", beef), "beef");
+    #[test]
+    fn lower_hex() {
+        let beef = Beef {};
+
+        assert_eq!(format!("{:x}", beef), "beef");
+    }
+
+    #[test]
+    fn lower_hex_alt() {
+        let beef = Beef {};
+
+        assert_eq!(format!("{:#x}", beef), "0xbeef");
+    }
+
+    #[test]
+    fn upper_hex() {
+        let beef = Beef {};
+
+        assert_eq!(format!("{:X}", beef), "BEEF");
+    }
+
+    #[test]
+    fn upper_hex_alt() {
+        let beef = Beef {};
+
+        assert_eq!(format!("{:#X}", beef), "0xBEEF");
+    }
 }
 
-#[test]
-fn lower_hex_alt() {
-    let beef = Beef {};
+mod debug {
+    use super::*;
 
-    assert_eq!(format!("{:#x}", beef), "0xbeef");
-}
+    #[test]
+    fn lower_hex() {
+        let beef = Beef {};
 
-#[test]
-fn upper_hex() {
-    let beef = Beef {};
+        assert_eq!(format!("{:x?}", beef), "beef");
+    }
 
-    assert_eq!(format!("{:X}", beef), "BEEF");
-}
+    #[test]
+    fn lower_hex_alt() {
+        let beef = Beef {};
 
-#[test]
-fn upper_hex_alt() {
-    let beef = Beef {};
+        assert_eq!(format!("{:#x?}", beef), "0xbeef");
+    }
 
-    assert_eq!(format!("{:#X}", beef), "0xBEEF");
+    #[test]
+    fn upper_hex() {
+        let beef = Beef {};
+
+        assert_eq!(format!("{:X?}", beef), "BEEF");
+    }
+
+    #[test]
+    fn upper_hex_alt() {
+        let beef = Beef {};
+
+        assert_eq!(format!("{:#X?}", beef), "0xBEEF");
+    }
 }


### PR DESCRIPTION
- Add tests
- Bump to `0.1.2`

Resolves: #10